### PR TITLE
Fix language picker constant

### DIFF
--- a/lib/views/profile/widgets/edit_profile_bottomsheet.dart
+++ b/lib/views/profile/widgets/edit_profile_bottomsheet.dart
@@ -231,15 +231,508 @@ class _EditProfileBottomSheetState extends State<EditProfileBottomSheet> {
             child: Row(
               children: [
                 Image.asset(
-                  'assets/images/flags/${profileState.language}.png',
+                  profileState.language == 'en'
+                      ? usaFlag
+                      : profileState.language == 'is'
+                          ? icelandFlag
+                          : profileState.language == 'de'
+                              ? germanyFlag
+                              : profileState.language == 'no'
+                                  ? norwegianFlag
+                                  : profileState.language == 'it'
+                                      ? italyFlag
+                                      : profileState.language == 'af'
+                                          ? southafricaFlag
+                                          : profileState.language == 'bn'
+                                              ? bangladeshFlag
+                                              : profileState.language == 'ca'
+                                                  ? cataloniaFlag
+                                                  : profileState.language ==
+                                                          'cs'
+                                                      ? czechFlag
+                                                      : profileState.language ==
+                                                              'cy'
+                                                          ? walesFlag
+                                                          : profileState.language ==
+                                                                  'da'
+                                                              ? denmarkFlag
+                                                              : profileState
+                                                                          .language ==
+                                                                      'el'
+                                                                  ? greeceFlag
+                                                                  : profileState
+                                                                              .language ==
+                                                                          'es'
+                                                                      ? spainFlag
+                                                                      : profileState
+                                                                                  .language ==
+                                                                              'et'
+                                                                          ? estoniaFlag
+                                                                          : profileState
+                                                                                      .language ==
+                                                                                  'eu'
+                                                                              ? basqueFlag
+                                                                              : profileState
+                                                                                          .language ==
+                                                                                      'fa'
+                                                                                  ? persiaFlag
+                                                                                  : profileState
+                                                                                              .language ==
+                                                                                          'fi'
+                                                                                      ? finlandFlag
+                                                                                      : profileState
+                                                                                                  .language ==
+                                                                                              'fr'
+                                                                                          ? franceFlag
+                                                                                          : profileState
+                                                                                                      .language ==
+                                                                                                  'gl'
+                                                                                              ? galaciaFlag
+                                                                                              : profileState
+                                                                                                          .language ==
+                                                                                                      'he'
+                                                                                                  ? israelFlag
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'hi'
+                                                                                                  ? hindiFlag
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'hr'
+                                                                                                  ? croatiaFlag
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'hu'
+                                                                                                  ? hungaryFlag
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'hy'
+                                                                                                  ? armeniaFlag
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'id'
+                                                                                                  ? indonesiaFlag
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'ja'
+                                                                                                  ? japanFlag
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'kn'
+                                                                                                  ? kannadaFlag
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'ko'
+                                                                                                  ? koreaFlag
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'lo'
+                                                                                                  ? laosFlag
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'lt'
+                                                                                                  ? lithuaniaFlag
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'lv'
+                                                                                                  ? latviaFlag
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'mk'
+                                                                                                  ? macedoniaFlag
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'ne'
+                                                                                                  ? nepalFlag
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'nl'
+                                                                                                  ? netherlandsFlag
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'pa'
+                                                                                                  ? punjabFlag
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'pl'
+                                                                                                  ? polandFlag
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'pt'
+                                                                                                  ? portugalFlag
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'ro'
+                                                                                                  ? romaniaFlag
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'ru'
+                                                                                                  ? russiaFlag
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'sl'
+                                                                                                  ? sloveniaFlag
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'sv'
+                                                                                                  ? swedenFlag
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'ta'
+                                                                                                  ? tamilFlag
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'te'
+                                                                                                  ? teluguFlag
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'th'
+                                                                                                  ? thailandFlag
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'tr'
+                                                                                                  ? turkeyFlag
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'uk'
+                                                                                                  ? ukraineFlag
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'ur'
+                                                                                                  ? pakistanFlag
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'vi'
+                                                                                                  ? vietnamFlag
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'zh'
+                                                                                                  ? chinaFlag
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'bg'
+                                                                                                  ? bulgariaFlag
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'gu'
+                                                                                                  ? gujaratiFlag
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'ka'
+                                                                                                  ? georgiaFlag
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'kk'
+                                                                                                  ? kazakhFlag
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'km'
+                                                                                                  ? cambodiaFlag
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'ky'
+                                                                                                  ? kyrgyzFlag
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'sk'
+                                                                                                  ? slovakiaFlag
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'sw'
+                                                                                                  ? kenyaFlag
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'tl'
+                                                                                                  ? tagalogFlag
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'zu'
+                                                                                                  ? zuluFlag
+                                                                                                  : norwegianFlag,
                   height: 32,
                   width: 32,
                 ),
                 sixteenHorizontalSpace,
                 Expanded(
                   child: LanguagePickerDropdown(
-                      initialValue: Language.fromIsoCode(profileState.language),
-                      languages: Languages.defaultLanguages,
+                      initialValue: profileState.language == 'is'
+                          ? Languages.icelandic
+                          : profileState.language == 'de'
+                              ? Languages.german
+                              : profileState.language == 'no'
+                                  ? Languages.norwegian
+                                  : profileState.language == 'it'
+                                      ? Languages.italian
+                                      : profileState.language == 'af'
+                                          ? Languages.afrikaans
+                                          : profileState.language == 'bn'
+                                              ? Languages.bengali
+                                              : profileState.language == 'ca'
+                                                  ? Languages.catalan
+                                                  : profileState.language == 'cs'
+                                                      ? Languages.czech
+                                                      : profileState.language ==
+                                                              'cy'
+                                                          ? Languages.welsh
+                                                          : profileState.language ==
+                                                                  'da'
+                                                              ? Languages.danish
+                                                              : profileState
+                                                                          .language ==
+                                                                      'el'
+                                              ? Languages.greekModern1453
+                                                                  : profileState
+                                                                              .language ==
+                                                                          'es'
+                                                                      ? Languages.spanish
+                                                                      : profileState
+                                                                                  .language ==
+                                                                              'et'
+                                                                          ? Languages.estonian
+                                                                          : profileState
+                                                                                      .language ==
+                                                                                  'eu'
+                                                                              ? Languages.basque
+                                                                              : profileState
+                                                                                          .language ==
+                                                                                      'fa'
+                                                                                  ? Languages.persian
+                                                                                  : profileState
+                                                                                              .language ==
+                                                                                          'fi'
+                                                                                      ? Languages.finnish
+                                                                                      : profileState
+                                                                                                  .language ==
+                                                                                              'fr'
+                                                                                          ? Languages.french
+                                                                                          : profileState
+                                                                                                      .language ==
+                                                                                                  'gl'
+                                                                                              ? Languages.galician
+                                                                                              : profileState
+                                                                                                          .language ==
+                                                                                                      'he'
+                                                                                                  ? Languages.hebrew
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'hi'
+                                                                                                  ? Languages.hindi
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'hr'
+                                                                                                  ? Languages.croatian
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'hu'
+                                                                                                  ? Languages.hungarian
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'hy'
+                                                                                                  ? Languages.armenian
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'id'
+                                                                                                  ? Languages.indonesian
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'ja'
+                                                                                                  ? Languages.japanese
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'kn'
+                                                                                                  ? Languages.kannada
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'ko'
+                                                                                                  ? Languages.korean
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'lo'
+                                                                                                  ? Languages.lao
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'lt'
+                                                                                                  ? Languages.lithuanian
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'lv'
+                                                                                                  ? Languages.latvian
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'mk'
+                                                                                                  ? Languages.macedonian
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'ne'
+                                                                                                  ? Languages.nepali
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'nl'
+                                                                                                  ? Languages.dutch
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'pa'
+                                                                                                  ? Languages.panjabi
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'pl'
+                                                                                                  ? Languages.polish
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'pt'
+                                                                                                  ? Languages.portuguese
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'ro'
+                                                                                                  ? Languages.romanian
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'ru'
+                                                                                                  ? Languages.russian
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'sl'
+                                                                                                  ? Languages.slovenian
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'sv'
+                                                                                                  ? Languages.swedish
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'ta'
+                                                                                                  ? Languages.tamil
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'te'
+                                                                                                  ? Languages.telugu
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'th'
+                                                                                                  ? Languages.thai
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'tr'
+                                                                                                  ? Languages.turkish
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'uk'
+                                                                                                  ? Languages.ukrainian
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'ur'
+                                                                                                  ? Languages.urdu
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'vi'
+                                                                                                  ? Languages.vietnamese
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'zh'
+                                                                                                  ? Languages.chineseSimplified
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'bg'
+                                                                                                  ? Languages.bulgarian
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'gu'
+                                                                                                  ? Languages.gujarati
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'ka'
+                                                                                                  ? Languages.georgian
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'kk'
+                                                                                                  ? Languages.kazakh
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'km'
+                                                                                                  ? Languages.centralKhmer
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'ky'
+                                                                                                  ? Languages.kirghiz
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'sk'
+                                                                                                  ? Languages.slovak
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'sw'
+                                                                                                  ? Languages.swahili
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'tl'
+                                                                                                  ? Languages.tagalog
+                                                                                                  : profileState
+                                                                                                          .language ==
+                                                                                                      'zu'
+                                                                                                  ? Languages.zulu
+                                                                                                  : Languages.english,
+                      languages: [
+                        Languages.afrikaans,
+                        Languages.armenian,
+                        Languages.basque,
+                        Languages.bengali,
+                        Languages.bulgarian,
+                        Languages.catalan,
+                        Languages.croatian,
+                        Languages.czech,
+                        Languages.danish,
+                        Languages.dutch,
+                        Languages.english,
+                        Languages.estonian,
+                        Languages.finnish,
+                        Languages.french,
+                        Languages.german,
+                        Languages.galician,
+                        Languages.georgian,
+                        Languages.greekModern1453,
+                        Languages.gujarati,
+                        Languages.icelandic,
+                        Languages.italian,
+                        Languages.hebrew,
+                        Languages.hindi,
+                        Languages.hungarian,
+                        Languages.indonesian,
+                        Languages.japanese,
+                        Languages.kannada,
+                        Languages.kazakh,
+                        Languages.centralKhmer,
+                        Languages.kirghiz,
+                        Languages.korean,
+                        Languages.lao,
+                        Languages.lithuanian,
+                        Languages.latvian,
+                        Languages.macedonian,
+                        Languages.norwegian,
+                        Languages.nepali,
+                        Languages.persian,
+                        Languages.panjabi,
+                        Languages.polish,
+                        Languages.portuguese,
+                        Languages.romanian,
+                        Languages.russian,
+                        Languages.spanish,
+                        Languages.slovenian,
+                        Languages.slovak,
+                        Languages.swahili,
+                        Languages.swedish,
+                        Languages.tagalog,
+                        Languages.tamil,
+                        Languages.telugu,
+                        Languages.thai,
+                        Languages.turkish,
+                        Languages.ukrainian,
+                        Languages.urdu,
+                        Languages.vietnamese,
+                        Languages.slovak,
+                        Languages.swahili,
+                        Languages.tagalog,
+                        Languages.welsh,
+                        Languages.zulu
+                      ],
                       onValuePicked: (language) {
                         profileState.changeLanguage(language.isoCode);
                         localizationState.setLocale(Locale(language.isoCode));


### PR DESCRIPTION
## Summary
- fix constant for Greek language in language picker (greekModern1453)

## Testing
- `flutter analyze`
- `flutter test` *(fails: Test directory "test" not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e5f5d4194832199f3658f1ad0dd5a